### PR TITLE
Upgrade for 1.16 and add new permissions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 4

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bukkit/src/main/java/com/github/games647/commandforward/bukkit/CommandForwardBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/commandforward/bukkit/CommandForwardBukkit.java
@@ -26,13 +26,13 @@ public class CommandForwardBukkit extends JavaPlugin {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0 || args.length == 1) {
-            sender.sendMessage(ChatColor.DARK_RED + "Command is missing");
+            sender.sendMessage(ChatColor.RED + "[CommandForward] Command is missing");
         } else {
             String channelPlayer = args[0];
 
             Optional<? extends Player> optPlayer = Bukkit.getOnlinePlayers().stream().findAny();
             if (!optPlayer.isPresent()) {
-                sender.sendMessage(ChatColor.DARK_RED + "Player not online for forwarding this command");
+                sender.sendMessage(ChatColor.RED + "[CommandForward] Player not online for forwarding this command");
                 return false;
             }
 
@@ -40,8 +40,31 @@ public class CommandForwardBukkit extends JavaPlugin {
 
             ByteArrayDataOutput dataOutput = ByteStreams.newDataOutput();
             if ("Console".equalsIgnoreCase(channelPlayer)) {
+                // TODO: Improve Me!!!
+                // TODO TODO TODO: Figure Out How To Check Permission of Command Sender
+                //if((sender instanceof Player) && (!sender.haspermission("commandforward.bukkit.command.forward.console"))) {
+                if(sender instanceof Player) {
+                  sender.sendMessage(ChatColor.RED + "[CommandForward] Sorry, you need permission, commandforward.bukkit.command.forward.console!");
+                  return true;
+                }
+
                 dataOutput.writeBoolean(false);
             } else {
+                // How do I make messageSender equal Player or null on check? Probably not possible in Java?
+                if(getServer().getPlayer(channelPlayer) == null) {
+                  sender.sendMessage(ChatColor.RED + "[CommandForward] Player, " + channelPlayer + ", not found");
+                  return true;
+                }
+
+                // TODO: Improve Me!!! Make It Possible To Specify A Single Whitelisted Perm To "Sudo" Per Perm (Perm Plugin Will Handle Fancy Stuff With Asterisks And All)
+                if((sender instanceof Player) && (!((Player) sender).getName().equalsIgnoreCase(channelPlayer))) {
+                  // TODO TODO TODO: Figure Out How To Check Permission of Command Sender
+                  //if(!sender.haspermission("commandforward.bukkit.command.forward.other")) {
+                    sender.sendMessage(ChatColor.RED + "[CommandForward] Sorry, you need permission, commandforward.bukkit.command.forward.other!");
+                    return true;
+                  //}
+                }
+
                 dataOutput.writeBoolean(sender instanceof Player);
                 messageSender = getServer().getPlayer(channelPlayer);
             }

--- a/bukkit/src/main/java/com/github/games647/commandforward/bukkit/CommandForwardBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/commandforward/bukkit/CommandForwardBukkit.java
@@ -25,56 +25,60 @@ public class CommandForwardBukkit extends JavaPlugin {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (args.length == 0 || args.length == 1) {
-            sender.sendMessage(ChatColor.RED + "[CommandForward] Command is missing");
-        } else {
-            String channelPlayer = args[0];
-
-            Optional<? extends Player> optPlayer = Bukkit.getOnlinePlayers().stream().findAny();
-            if (!optPlayer.isPresent()) {
-                sender.sendMessage(ChatColor.RED + "[CommandForward] Player not online for forwarding this command");
-                return false;
-            }
-
-            Player messageSender = optPlayer.get();
-
-            ByteArrayDataOutput dataOutput = ByteStreams.newDataOutput();
-            if ("Console".equalsIgnoreCase(channelPlayer)) {
-                // TODO: Improve Me!!!
-                // TODO TODO TODO: Figure Out How To Check Permission of Command Sender
-                //if((sender instanceof Player) && (!sender.haspermission("commandforward.bukkit.command.forward.console"))) {
-                if(sender instanceof Player) {
-                  sender.sendMessage(ChatColor.RED + "[CommandForward] Sorry, you need permission, commandforward.bukkit.command.forward.console!");
-                  return true;
-                }
-
-                dataOutput.writeBoolean(false);
-            } else {
-                // How do I make messageSender equal Player or null on check? Probably not possible in Java?
-                if(getServer().getPlayer(channelPlayer) == null) {
-                  sender.sendMessage(ChatColor.RED + "[CommandForward] Player, " + channelPlayer + ", not found");
-                  return true;
-                }
-
-                // TODO: Improve Me!!! Make It Possible To Specify A Single Whitelisted Perm To "Sudo" Per Perm (Perm Plugin Will Handle Fancy Stuff With Asterisks And All)
-                if((sender instanceof Player) && (!((Player) sender).getName().equalsIgnoreCase(channelPlayer))) {
-                  // TODO TODO TODO: Figure Out How To Check Permission of Command Sender
-                  //if(!sender.haspermission("commandforward.bukkit.command.forward.other")) {
-                    sender.sendMessage(ChatColor.RED + "[CommandForward] Sorry, you need permission, commandforward.bukkit.command.forward.other!");
-                    return true;
-                  //}
-                }
-
-                dataOutput.writeBoolean(sender instanceof Player);
-                messageSender = getServer().getPlayer(channelPlayer);
-            }
-
-            dataOutput.writeUTF(args[1]);
-            dataOutput.writeUTF(Joiner.on(' ').join(Arrays.copyOfRange(args, 2, args.length)));
-            dataOutput.writeBoolean(sender.isOp());
-            messageSender.sendPluginMessage(this, MESSAGE_CHANNEL, dataOutput.toByteArray());
+        if (args.length <= 1) {
+            sendErrorMessage(sender, "Wrong command, Missing arguments");
+            return false;
         }
 
+        String channelPlayer = args[0];
+
+        Optional<? extends Player> optPlayer = Bukkit.getOnlinePlayers().stream().findAny();
+        if (!optPlayer.isPresent()) {
+            sendErrorMessage(sender, "No player is online to forward this command");
+            return true;
+        }
+
+        Player messageSender = optPlayer.get();
+
+        ByteArrayDataOutput dataOutput = ByteStreams.newDataOutput();
+        if ("Console".equalsIgnoreCase(channelPlayer)) {
+            if (!Permissions.FORWARD_CONSOLE.isSetOn(sender)) {
+                sendErrorMessage(sender, Permissions.ERROR_MESSAGE);
+                return true;
+            }
+
+            dataOutput.writeBoolean(false);
+        } else {
+            if(sender instanceof Player && !sender.getName().equalsIgnoreCase(channelPlayer) && !Permissions.FORWARD_OTHER.isSetOn(sender)) {
+                sendErrorMessage(sender, Permissions.ERROR_MESSAGE);
+                return true;
+            }
+            
+            if(getServer().getPlayer(channelPlayer) == null) {
+                sendErrorMessage(sender, "Player '" + channelPlayer + "' not found");
+                return true;
+            }
+
+            dataOutput.writeBoolean(true);
+            messageSender = getServer().getPlayer(channelPlayer);
+        }
+
+        dataOutput.writeUTF(args[1]);
+        dataOutput.writeUTF(Joiner.on(' ').join(Arrays.copyOfRange(args, 2, args.length)));
+        dataOutput.writeBoolean(sender.isOp());
+        messageSender.sendPluginMessage(this, MESSAGE_CHANNEL, dataOutput.toByteArray());
+
         return true;
+    }
+
+    /**
+     * Print an error message
+     *
+     * @param sender  Sender that execute the current command
+     * @param message Message to send to command sender
+     */
+    private void sendErrorMessage(CommandSender sender, String message) {
+        sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                    "&3[&6" + this.getName() + "&3]&c " + message));
     }
 }

--- a/bukkit/src/main/java/com/github/games647/commandforward/bukkit/CommandForwardBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/commandforward/bukkit/CommandForwardBukkit.java
@@ -17,6 +17,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class CommandForwardBukkit extends JavaPlugin {
 
     private static final String MESSAGE_CHANNEL = "commandforward:cmd";
+    private final String PLUGIN_NAME_PREFIX = ChatColor.DARK_AQUA + "[" + ChatColor.GOLD + this.getName() + ChatColor.DARK_AQUA + "] ";
 
     @Override
     public void onEnable() {
@@ -78,7 +79,6 @@ public class CommandForwardBukkit extends JavaPlugin {
      * @param message Message to send to command sender
      */
     private void sendErrorMessage(CommandSender sender, String message) {
-        sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                    "&3[&6" + this.getName() + "&3]&c " + message));
+        sender.sendMessage(this.PLUGIN_NAME_PREFIX + ChatColor.RED + message);
     }
 }

--- a/bukkit/src/main/java/com/github/games647/commandforward/bukkit/Permissions.java
+++ b/bukkit/src/main/java/com/github/games647/commandforward/bukkit/Permissions.java
@@ -1,0 +1,27 @@
+package com.github.games647.commandforward.bukkit;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public enum Permissions {
+    FORWARD("commandforward.bukkit.command.forward"),
+    FORWARD_CONSOLE("commandforward.bukkit.command.forward.console"),
+    FORWARD_OTHER("commandforward.bukkit.command.forward.other");
+
+    private String permission;
+    public static String ERROR_MESSAGE = "You are not allowed to execute this command";
+
+    private Permissions(final String perm) {
+        this.permission = perm;
+    }
+
+    /**
+     * Define if the permission is set
+     *
+     * @param player Player on which check the permissions
+     * @return Return a boolean to define if the permission is set
+     */
+    public Boolean isSetOn(final CommandSender player) {
+        return player != null && (!(player instanceof Player) || ((Player)player).hasPermission(this.permission));
+    }
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -17,5 +17,18 @@ api-version: 1.13
 commands:
     forward:
         description: 'Forward a command to the bungee proxy'
-        usage: /<command> <player-ign or console> <command> [arg]
+        usage: /<command> <player-name or 'console'> <bungee_command> [arg]
         permission: ${project.artifactId}.command.forward
+permissions:
+    ${project.artifactId}.command.forward.*:
+        description: 'Allow to use all features of forward command'
+        children:
+            ${project.artifactId}.command.forward: true
+            ${project.artifactId}.command.forward.console: true
+            ${project.artifactId}.command.forward.other: true
+    ${project.artifactId}.command.forward:
+        description: 'Allow to use base forward command'
+    ${project.artifactId}.command.forward.console:
+        description: 'Allow to use console in forward command'
+    ${project.artifactId}.command.forward.other:
+        description: 'Allow to use another player than ourself in forward command'

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -17,5 +17,5 @@ api-version: 1.13
 commands:
     forward:
         description: 'Forward a command to the bungee proxy'
-        usage: /<command> <proxyCommand> [arg]
+        usage: /<command> <player-ign or console> <command> [arg]
         permission: ${project.artifactId}.command.forward

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -15,6 +15,15 @@
 
     <!--Represents the main plugin-->
     <name>CommandForwardBungee</name>
+
+    <!-- You May Want To Switch To Waterfall -->
+    <repositories>
+        <!--BungeeCord-API -->
+        <repository>
+            <id>bungeecord-repo</id>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>

--- a/bungee/src/main/java/com/github/games647/commandforward/bungee/CommandForwardBungee.java
+++ b/bungee/src/main/java/com/github/games647/commandforward/bungee/CommandForwardBungee.java
@@ -5,15 +5,12 @@ import com.google.common.io.ByteStreams;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Level;
 
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.PluginMessageEvent;
-import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
@@ -41,55 +38,49 @@ public class CommandForwardBungee extends Plugin implements Listener {
 
         //check if the message is sent from the server
         if (Server.class.isAssignableFrom(messageEvent.getSender().getClass())) {
-            parseMessage((CommandSender) messageEvent.getReceiver(), ByteStreams.newDataInput(messageEvent.getData()));
+            parseMessage((CommandSender) messageEvent.getReceiver(),
+                ByteStreams.newDataInput(messageEvent.getData()));
         }
     }
 
     private void parseMessage(CommandSender sender, ByteArrayDataInput dataInput) {
-        boolean isPlayer = dataInput.readBoolean();
-        String command = dataInput.readUTF();
-        String arguments = dataInput.readUTF();
-
-        CommandSender invoker = getProxy().getConsole();
-        if (isPlayer) {
-            invoker = sender;
-        }
+        final boolean isPlayer = dataInput.readBoolean();
+        final String command = dataInput.readUTF();
+        final String arguments = dataInput.readUTF();
+        final CommandSender invoker = (isPlayer) ? sender : getProxy().getConsole();
 
         invokeCommand(invoker, dataInput.readBoolean(), command, arguments);
     }
 
     private void invokeCommand(CommandSender invoker, boolean isOp, String command, String arguments) {
         PluginManager pluginManager = getProxy().getPluginManager();
-        //if (isOp) { // TODO: Make OP Configurable and Fix command map!!!
-        if (false) {
-            try {
-                // TODO: Fix using the command map! https://github.com/games647/CommandForward/issues/3
-                Map<String, Command> commandMap = (Map<String, Command>) pluginManager.getClass()
-                        .getField("commandMap").get(pluginManager);
 
-                Command pluginCmd = commandMap.get(command);
-                if (pluginCmd == null) {
-                    invoker.sendMessage(new ComponentBuilder("[CommandForward] Command '" + command + "' not found")
-                            .color(ChatColor.RED)
-                            .create());
-                } else {
+        if (isOp) {
+            pluginManager.getCommands()
+                .stream()
+                .filter(entry -> entry.getKey().equals(command.toLowerCase())).findFirst()
+                .map(Map.Entry::getValue)
+                .map(pluginCmd -> {
                     pluginCmd.execute(invoker, arguments.split(" "));
-                }
-            } catch (NoSuchFieldException | IllegalAccessException ex) {
-                String exMess = ex.getMessage();
-                BaseComponent[] message = new ComponentBuilder("[CommandForward]  Error occurred executing command '" + exMess + "'")
-                        .color(ChatColor.RED)
-                        .create();
-                invoker.sendMessage(message);
-                getLogger().log(Level.WARNING, "[CommandForward]  Cannot access command map for executing command", ex);
-            }
+                    return pluginCmd;
+                }).orElseGet(() -> {
+                    sendErrorMessage(invoker, "Unknown command : " + command);
+                    return null;
+                });
         } else {
-            String commandLine = command + ' ' + arguments;
-            if(!pluginManager.dispatchCommand(invoker, commandLine)) {
-              invoker.sendMessage(new ComponentBuilder("[CommandForward] Command '" + command + "' not found")
-                      .color(ChatColor.RED)
-                      .create());
-            }
+            pluginManager.dispatchCommand(invoker, command + " " + arguments);
         }
+    }
+
+    /**
+     * Print an error message
+     *
+     * @param sender  Sender that execute the current command
+     * @param message Message to send to command sender
+     */
+    private void sendErrorMessage(CommandSender sender, String message) {
+        sender.sendMessage(
+            new ComponentBuilder(String.format("[%s] %s", this.getDescription().getName(), message))
+                .color(ChatColor.RED).append(message).create());
     }
 }

--- a/bungee/src/main/java/com/github/games647/commandforward/bungee/CommandForwardBungee.java
+++ b/bungee/src/main/java/com/github/games647/commandforward/bungee/CommandForwardBungee.java
@@ -60,14 +60,16 @@ public class CommandForwardBungee extends Plugin implements Listener {
 
     private void invokeCommand(CommandSender invoker, boolean isOp, String command, String arguments) {
         PluginManager pluginManager = getProxy().getPluginManager();
-        if (isOp) {
+        //if (isOp) { // TODO: Make OP Configurable and Fix command map!!!
+        if (false) {
             try {
+                // TODO: Fix using the command map! https://github.com/games647/CommandForward/issues/3
                 Map<String, Command> commandMap = (Map<String, Command>) pluginManager.getClass()
                         .getField("commandMap").get(pluginManager);
 
                 Command pluginCmd = commandMap.get(command);
                 if (pluginCmd == null) {
-                    invoker.sendMessage(new ComponentBuilder("Command not known")
+                    invoker.sendMessage(new ComponentBuilder("[CommandForward] Command '" + command + "' not found")
                             .color(ChatColor.RED)
                             .create());
                 } else {
@@ -75,15 +77,19 @@ public class CommandForwardBungee extends Plugin implements Listener {
                 }
             } catch (NoSuchFieldException | IllegalAccessException ex) {
                 String exMess = ex.getMessage();
-                BaseComponent[] message = new ComponentBuilder("Error occurred executing command " + exMess)
+                BaseComponent[] message = new ComponentBuilder("[CommandForward]  Error occurred executing command '" + exMess + "'")
                         .color(ChatColor.RED)
                         .create();
                 invoker.sendMessage(message);
-                getLogger().log(Level.WARNING, "Cannot access command map for executing command", ex);
+                getLogger().log(Level.WARNING, "[CommandForward]  Cannot access command map for executing command", ex);
             }
         } else {
             String commandLine = command + ' ' + arguments;
-            pluginManager.dispatchCommand(invoker, commandLine);
+            if(!pluginManager.dispatchCommand(invoker, commandLine)) {
+              invoker.sendMessage(new ComponentBuilder("[CommandForward] Command '" + command + "' not found")
+                      .color(ChatColor.RED)
+                      .create());
+            }
         }
     }
 }

--- a/bungee/src/main/java/com/github/games647/commandforward/bungee/CommandForwardBungee.java
+++ b/bungee/src/main/java/com/github/games647/commandforward/bungee/CommandForwardBungee.java
@@ -58,7 +58,8 @@ public class CommandForwardBungee extends Plugin implements Listener {
         if (isOp) {
             pluginManager.getCommands()
                 .stream()
-                .filter(entry -> entry.getKey().equals(command.toLowerCase())).findFirst()
+                .filter(entry -> entry.getKey().equals(command.toLowerCase()))
+                .findFirst()
                 .map(Map.Entry::getValue)
                 .map(pluginCmd -> {
                     pluginCmd.execute(invoker, arguments.split(" "));

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <name>CommandForward</name>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
 
     <url>https://www.spigotmc.org/resources/</url>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <name>CommandForward</name>
-    <version>0.3.2</version>
+    <version>0.4.0</version>
 
     <url>https://www.spigotmc.org/resources/</url>
     <description>

--- a/universal/pom.xml
+++ b/universal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/universal/pom.xml
+++ b/universal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Hello,

I take the continuation of the PR #4 started by @alexis-evelyn.

Work done :
- Fix commandMap, use of method getCommands instead of using reflection
- Add 3 new permissions and a list of permissions in plugin.yml
  - `commandforward.bukkit.command.forward.console`: Allow to use console as an executor for the command
  - `commandforward.bukkit.command.forward.other`: Allow to use to execute the command for another player
  - `commandforward.bukkit.command.forward.*`: Give access to all features of forward command
- Fix an issue where the console couldn't execute a command for a player
- Add generic method to send error message

Best regards,
EpiCanard