### PR TITLE
Update for Folia and add * wild card forwarder

### DIFF
--- a/bukkit/src/main/java/com/github/games647/commandforward/bukkit/command/ForwardCommand.java
+++ b/bukkit/src/main/java/com/github/games647/commandforward/bukkit/command/ForwardCommand.java
@@ -35,6 +35,15 @@ public class ForwardCommand extends MessageCommand {
             Bukkit.getOnlinePlayers().stream().findAny().ifPresent(messageSender -> {
                 sendForwardCommand(messageSender, false, args[1], dropFirstArgs(args, ARG_START), sender.isOp());
             });
+        }  else if ("*".equalsIgnoreCase(channelPlayer)) {
+            if (!Permissions.FORWARD_OTHER.isSetOn(sender)) {
+                sendErrorMessage(sender, Permissions.ERROR_MESSAGE);
+                return true;
+            }
+
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                sendForwardCommand(player, true, args[1], dropFirstArgs(args, ARG_START), sender.isOp());
+            }
         } else {
             if (sender instanceof Player && !sender.getName().equalsIgnoreCase(channelPlayer)
                     && !Permissions.FORWARD_OTHER.isSetOn(sender)) {

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ description: |
     ${project.description}
 website: ${project.url}
 dev-url: ${project.url}
+folia-supported: true
 
 # This plugin don't have to be transformed for compatibility with Minecraft >= 1.13
 api-version: '1.13'


### PR DESCRIPTION
### Summary of your change
This will add support for Folia (Paper Fork by PaperMC). 

I also added a wildcard for a playername. This will also allow you to mass run forward commands, helpful for moving people to the lobby. Example: `/forward * server lobby`


### Related issue
- Unspported on Folia
