### PR TITLE
add console@<player name>, which allows routing a console command via a specific player

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bukkit/src/main/java/com/github/games647/commandforward/bukkit/command/ForwardCommand.java
+++ b/bukkit/src/main/java/com/github/games647/commandforward/bukkit/command/ForwardCommand.java
@@ -44,6 +44,20 @@ public class ForwardCommand extends MessageCommand {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 sendForwardCommand(player, true, args[1], dropFirstArgs(args, ARG_START), sender.isOp());
             }
+        } else if (channelPlayer.toLowerCase().startsWith("console@")) {
+            if (!Permissions.FORWARD_CONSOLE.isSetOn(sender)) {
+                sendErrorMessage(sender, Permissions.ERROR_MESSAGE);
+                return true;
+            }
+
+            channelPlayer = channelPlayer.replace("console@", "");
+            Player messageSender = Bukkit.getServer().getPlayer(channelPlayer);
+            if (messageSender == null) {
+                sendErrorMessage(sender, "Player '" + channelPlayer + "' not found");
+                return true;
+            }
+
+            sendForwardCommand(messageSender, false, args[1], dropFirstArgs(args, ARG_START), sender.isOp());
         } else {
             if (sender instanceof Player && !sender.getName().equalsIgnoreCase(channelPlayer)
                     && !Permissions.FORWARD_OTHER.isSetOn(sender)) {

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <name>CommandForward</name>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
 
     <url>https://dev.bukkit.org/projects/commandforward</url>
     <description>

--- a/universal/pom.xml
+++ b/universal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/universal/pom.xml
+++ b/universal/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <shadedArtifactAttached>false</shadedArtifactAttached>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>commandforward</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
# Problem:
In certain scenarios, NPCs are treated as players on the server. When using the current /forward console command, the system selects a random player connection to forward the command. However, this can sometimes select an NPC or bot, which might not have a valid BungeeCord connection, leading to failed message routing.

# Solution:
By adding the ability to specify a player directly using console@<player_name>, users can ensure that the console command is forwarded via a valid, real player’s connection, avoiding the risk of selecting an invalid NPC or bot connection.

# Updated SpigotMC section:
(on the Using It list):
- Example Execute as Console (using a specific player connection):
  /forward console@playerName ping
  bridgePlayer is the player which connection should be used, but it will be executed as bungee console there.
